### PR TITLE
Commented out the padding important

### DIFF
--- a/src/styles/global.module.css
+++ b/src/styles/global.module.css
@@ -9,9 +9,9 @@
   letter-spacing: 0;
 }
 
-button {
+/* button {
   padding: 0px !important;
-}
+} */
 
 h1,
 h2,


### PR DESCRIPTION
## 🛠️ PR Title: Remove Global Button Padding Override in GruveEventWidget

---

### 📄 Description

This pull request removes the following global CSS override from the `GruveEventWidget` package:

```css
/* button {
  padding: 0px !important;
} */

#### Example
*From this*
<img width="642" alt="Screenshot 2025-05-04 at 00 32 40" src="https://github.com/user-attachments/assets/614125f9-7172-422b-bbdf-19b4051eebf0" />

*To this*
<img width="542" alt="Screenshot 2025-05-04 at 01 01 07" src="https://github.com/user-attachments/assets/ca9669d0-7112-4946-a9fc-6d51b562630d" />

It affects these too
<img width="950" alt="Screenshot 2025-05-04 at 00 32 56" src="https://github.com/user-attachments/assets/11f2c0a0-00ac-4488-acba-91fa37d7bde1" />
<img width="990" alt="Screenshot 2025-05-04 at 00 33 16" src="https://github.com/user-attachments/assets/52400c65-558c-4a86-b035-1b07fe2f3c53" />
